### PR TITLE
Added DummyQueryCollection for easier mocking of HttpRequests

### DIFF
--- a/AzureFunctions.TestHelpers/DummyQueryCollection.cs
+++ b/AzureFunctions.TestHelpers/DummyQueryCollection.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace AzureFunctions.TestHelpers
+{
+    public sealed class DummyQueryCollection : IQueryCollection
+    {
+        private Dictionary<string, StringValues> innerDict = new Dictionary<string, StringValues>();
+
+        public StringValues this[string key] => innerDict[key];
+        public int Count => innerDict.Count;
+        public ICollection<string> Keys => innerDict.Keys;
+        public bool ContainsKey(string key) => innerDict.ContainsKey(key);
+        public IEnumerator<KeyValuePair<string, StringValues>> GetEnumerator() => innerDict.GetEnumerator();
+        public bool TryGetValue(string key, out StringValues value) => innerDict.TryGetValue(key, out value);
+        IEnumerator IEnumerable.GetEnumerator() => innerDict.GetEnumerator();
+
+        public void Add(string key, StringValues value) => innerDict.Add(key, value);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You'll ❤ the feedback!
 
 ## Configure Services for Dependency Injection
 
-I just found out the default `ConfigureServices` on the `HostBuilder` also works. 
+I just found out the default `ConfigureServices` on the `HostBuilder` also works.
 But if it makes more sense to you to configure services on the `WebJobsBuilder` since
 you also configure the `Startup` there you can use:
 
@@ -96,6 +96,19 @@ var request = new DummyHttpRequest
     Headers = {
         ["Authorization"] = $"Bearer {token}",
         ["Content-Type"] =  "application/json"
+    }
+};
+```
+
+_New_: Now you can use a DummyQueryCollection to mock the url query:
+
+```c#
+var request = new DummyHttpRequest
+{
+    Query = new DummyQueryCollection
+    {
+        { "firstname", "Jane" },
+        { "lastname", "Doe" }
     }
 };
 ```


### PR DESCRIPTION
To make it easier to mock Http requests with query parameters, I created a simple wrapper around a dictionary which can be used instead of a QueryCollection.

I figured I might as well share!